### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -26,9 +26,9 @@ buttons	KEYWORD1
 ////////////////////////core
 begin	KEYWORD1
 update	KEYWORD1
-startupLogo  KEYWORD1
-Speaker  KEYWORD1
-Lcd  KEYWORD1
+startupLogo	KEYWORD1
+Speaker	KEYWORD1
+Lcd	KEYWORD1
 
 ////////////////////////buttons
 pressed	KEYWORD1
@@ -39,7 +39,7 @@ timeHeld	KEYWORD1
 BTN_A 	LITERAL1
 BTN_B 	LITERAL1
 BTN_C 	LITERAL1
-LED_PIN LITERAL1
+LED_PIN	LITERAL1
 
 ////////////////////////Display
 getBuffer	KEYWORD1


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords