### PR TITLE
Fixed path variables in component.mk

### DIFF
--- a/component.mk
+++ b/component.mk
@@ -3,5 +3,5 @@
 #
 # (Uses default behaviour of compiling all source files in directory, adding 'include' to include path.)
 
-COMPONENT_SRCDIRS := . src
-COMPONENT_ADD_INCLUDEDIRS := . src
+COMPONENT_SRCDIRS := src src/utility src/Fonts
+COMPONENT_ADD_INCLUDEDIRS := src


### PR DESCRIPTION
This fix is to correctly compile necessary source files in src/utility and src/Fonts using ESP-IDF.

* Added required subdirectories to the end of COMPONENT_SRCDIRS
* Removed "." from both paths