### PR TITLE
Quick fix for compilation errors in In_eSPI.{h,cpp}

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -615,7 +615,7 @@ uint16_t TFT_eSPI::readcommand16(uint8_t cmd_function, uint8_t index)
 {
   uint32_t reg;
 
-  reg |= (readcommand8(cmd_function, index + 0) <<  8);
+  reg  = (readcommand8(cmd_function, index + 0) <<  8);
   reg |= (readcommand8(cmd_function, index + 1) <<  0);
 
   return reg;
@@ -1196,7 +1196,7 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           //else     drawPixel((dw-len)+xp,h-dh,bitmap_bg);
           xp++;
         }
-        *ptr++;
+        ptr++;
         len -= 8;
       }
 
@@ -1345,7 +1345,7 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           px++;
           xp++;
         }
-        *ptr++;
+        ptr++;
         len -= 8;
       }
       if (np) pushColor(bitmap_fg, np);

--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -203,8 +203,8 @@
   #define set_mask(C) xset_mask[C] // 63fps Sprite rendering test 33% faster, graphicstest only 1.8% faster than shifting in real time
 
   // Real-time shifting alternative to above to save 1KByte RAM, 47 fps Sprite rendering test
-  //#define set_mask(C) ((C&0x80)>>7)<<TFT_D7 | ((C&0x40)>>6)<<TFT_D6 | ((C&0x20)>>5)<<TFT_D5 | ((C&0x10)>>4)<<TFT_D4 | \
-                        ((C&0x08)>>3)<<TFT_D3 | ((C&0x04)>>2)<<TFT_D2 | ((C&0x02)>>1)<<TFT_D1 | ((C&0x01)>>0)<<TFT_D0
+  /* #define set_mask(C) ((C&0x80)>>7)<<TFT_D7 | ((C&0x40)>>6)<<TFT_D6 | ((C&0x20)>>5)<<TFT_D5 | ((C&0x10)>>4)<<TFT_D4 | \
+                        ((C&0x08)>>3)<<TFT_D3 | ((C&0x04)>>2)<<TFT_D2 | ((C&0x02)>>1)<<TFT_D1 | ((C&0x01)>>0)<<TFT_D0 */
 
   // Write 8 bits to TFT
   #define tft_Write_8(C)  GPIO.out_w1tc = clr_mask; GPIO.out_w1ts = set_mask((uint8_t)C); WR_H


### PR DESCRIPTION
Hi. 
My ESP-IDF build system (latest copy) reports compilation errors in the latest commit.
They are actually warnings but are treated as errors by the build system in default settings.
Here is a quick fix for the errors.

* Multi-line comment in In_eSPI.h
* Uninitialized local variable in In_eSPI.cpp
* Unused pointer references in In_eSPI.cpp