### PR TITLE
Removed inline specifier from TFT_eSPI::setAddrWindow

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -2505,7 +2505,7 @@ void TFT_eSPI::setWindow(int16_t x0, int16_t y0, int16_t x1, int16_t y1)
 // Chip select stays low, use setWindow() from sketches
 
 #if defined (ESP8266) && !defined (RPI_WRITE_STROBE) && !defined (RPI_ILI9486_DRIVER)
-inline void TFT_eSPI::setAddrWindow(int32_t xs, int32_t ys, int32_t xe, int32_t ye)
+void TFT_eSPI::setAddrWindow(int32_t xs, int32_t ys, int32_t xe, int32_t ye)
 {
   //spi_begin();
 
@@ -2628,7 +2628,7 @@ void TFT_eSPI::setAddrWindow(int32_t xs, int32_t ys, int32_t xe, int32_t ye)
 #else
 
 #if defined (ESP8266) && defined (RPI_ILI9486_DRIVER) // This is for the RPi display that needs 16 bits
-inline void TFT_eSPI::setAddrWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
+void TFT_eSPI::setAddrWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
 {
   //spi_begin();
 
@@ -2705,7 +2705,7 @@ inline void TFT_eSPI::setAddrWindow(int32_t x0, int32_t y0, int32_t x1, int32_t 
 
 #else // This is for the ESP32
 
-inline void TFT_eSPI::setAddrWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
+void TFT_eSPI::setAddrWindow(int32_t x0, int32_t y0, int32_t x1, int32_t y1)
 {
   //spi_begin();
 


### PR DESCRIPTION
Sorry for bothering you again.

I've found that I cannot compile applications using `M5Display::drawJpg` (e.g., Tetris in the example) because the function `setAddrWindow` cannot be seen from outside of `TFT_eSPI`.
The function is defined with `inline` specifier in the source file (not in the header file).  This may hide the function symbol from outside of `TFT_eSPI` class even if it is declared as public member.

In this PR, I just removed `inline` specifier to resolve the problem. However, if you think that it should be an inline  function, you can (a) move the function definition to the header file, or (b) rename the function as `setAddrWindow_` (for example) and make it private, and then define a public version of `setAddrWindow` that just calls the inline version.