### PR TITLE
Fix for ESP-IDF compilation errors in In_eSPI.cpp

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -615,7 +615,7 @@ uint16_t TFT_eSPI::readcommand16(uint8_t cmd_function, uint8_t index)
 {
   uint32_t reg;
 
-  reg |= (readcommand8(cmd_function, index + 0) <<  8);
+  reg  = (readcommand8(cmd_function, index + 0) <<  8);
   reg |= (readcommand8(cmd_function, index + 1) <<  0);
 
   return reg;
@@ -1196,7 +1196,7 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           //else     drawPixel((dw-len)+xp,h-dh,bitmap_bg);
           xp++;
         }
-        *ptr++;
+        ptr++;
         len -= 8;
       }
 
@@ -1345,7 +1345,7 @@ void TFT_eSPI::pushImage(int32_t x, int32_t y, uint32_t w, uint32_t h, uint8_t *
           px++;
           xp++;
         }
-        *ptr++;
+        ptr++;
         len -= 8;
       }
       if (np) pushColor(bitmap_fg, np);


### PR DESCRIPTION
Hello.  Thank you for applying my PRs so far.
As I wrote in the comment  of ba252b0, some fixes in In_eSPI.cpp applied in 50b8518 are removed.  This causes the compilation errors (described in PR #59) with ESP-IDF again.  Since the compilation options in ESP-IDF are somewhat more strict than Arduino IDE, some kinds of warnings overlooked by Arduino IDE are treated as errors in ESP-IDF. In_eSPI.cpp in this commit is an instance that causes such errors.

I'll be grateful if you can apply this PR. I hope this does not cause any inconvenience to you.