### PR TITLE
TFT_eSPI continued

### DIFF
--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -14,25 +14,7 @@ void M5Display::begin() {
   ledcAttachPin(TFT_BL, BLK_PWM_CHANNEL);
   ledcWrite(BLK_PWM_CHANNEL, 80);
 }
-/*
-inline void M5Display::startWrite(void){
-#if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
-  if (locked) {locked = false; SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));}
-#endif
-  CS_L;
-}
 
-inline void M5Display::endWrite(void){
-#if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
-  if(!inTransaction) {if (!locked) {locked = true; SPI.endTransaction();}}
-#endif
-  CS_H;
-}
-
-inline void M5Display::writePixels(uint16_t * colors, uint32_t len){
-    SPI.writePixels((uint8_t*)colors , len * 2);
-}
-*/
 void M5Display::sleep() {
   startWrite();
   writecommand(ILI9341_SLPIN); // Software reset
@@ -62,7 +44,10 @@ void M5Display::drawBitmap(int16_t x0, int16_t y0, int16_t w, int16_t h, const u
 void M5Display::drawBitmap(int16_t x0, int16_t y0, int16_t w, int16_t h, uint8_t *data) {
   pushImage((int32_t)x0, (int32_t)y0, (uint32_t)w, (uint32_t)h, (uint16_t*)data);
 }
-
+void M5Display::progressBar(int x, int y, int w, int h, uint8_t val) {
+  drawRect(x, y, w, h, 0x09F1);
+  fillRect(x + 1, y + 1, w * (((float)val) / 100.0), h - 1, 0x09F1);
+}
 
 #include "utility/qrcode.h"
 void M5Display::qrcode(const char *string, uint16_t x, uint16_t y, uint8_t width, uint8_t version) {

--- a/src/M5Display.cpp
+++ b/src/M5Display.cpp
@@ -14,7 +14,7 @@ void M5Display::begin() {
   ledcAttachPin(TFT_BL, BLK_PWM_CHANNEL);
   ledcWrite(BLK_PWM_CHANNEL, 80);
 }
-
+/*
 inline void M5Display::startWrite(void){
 #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
   if (locked) {locked = false; SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));}
@@ -32,7 +32,7 @@ inline void M5Display::endWrite(void){
 inline void M5Display::writePixels(uint16_t * colors, uint32_t len){
     SPI.writePixels((uint8_t*)colors , len * 2);
 }
-
+*/
 void M5Display::sleep() {
   startWrite();
   writecommand(ILI9341_SLPIN); // Software reset

--- a/src/M5Display.h
+++ b/src/M5Display.h
@@ -25,8 +25,6 @@ class M5Display : public TFT_eSPI {
   void clear(uint32_t color=ILI9341_BLACK) { fillScreen(color); }
   void display() {}
 
-//  inline void startWrite() __attribute__((always_inline));
-//  inline void endWrite() __attribute__((always_inline));
   inline void startWrite(void){
   #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
     if (locked) {locked = false; SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));}
@@ -40,10 +38,11 @@ class M5Display : public TFT_eSPI {
     CS_H;
   }
   inline void writePixel(uint16_t color) { SPI.write16(color); }
-  //inline void writePixels(uint16_t *colors, uint32_t len);
   inline void writePixels(uint16_t * colors, uint32_t len){
       SPI.writePixels((uint8_t*)colors , len * 2);
   }
+  void progressBar(int x, int y, int w, int h, uint8_t val);
+
   #define setFont setFreeFont
 
   void qrcode(const char *string, uint16_t x = 50, uint16_t y = 10, uint8_t width = 220, uint8_t version = 6);

--- a/src/M5Display.h
+++ b/src/M5Display.h
@@ -25,10 +25,25 @@ class M5Display : public TFT_eSPI {
   void clear(uint32_t color=ILI9341_BLACK) { fillScreen(color); }
   void display() {}
 
-  inline void startWrite() __attribute__((always_inline));
-  inline void endWrite() __attribute__((always_inline));
+//  inline void startWrite() __attribute__((always_inline));
+//  inline void endWrite() __attribute__((always_inline));
+  inline void startWrite(void){
+  #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
+    if (locked) {locked = false; SPI.beginTransaction(SPISettings(SPI_FREQUENCY, MSBFIRST, SPI_MODE0));}
+  #endif
+    CS_L;
+  }
+  inline void endWrite(void){
+  #if defined (SPI_HAS_TRANSACTION) && defined (SUPPORT_TRANSACTIONS) && !defined(ESP32_PARALLEL)
+    if(!inTransaction) {if (!locked) {locked = true; SPI.endTransaction();}}
+  #endif
+    CS_H;
+  }
   inline void writePixel(uint16_t color) { SPI.write16(color); }
-  inline void writePixels(uint16_t *colors, uint32_t len);
+  //inline void writePixels(uint16_t *colors, uint32_t len);
+  inline void writePixels(uint16_t * colors, uint32_t len){
+      SPI.writePixels((uint8_t*)colors , len * 2);
+  }
   #define setFont setFreeFont
 
   void qrcode(const char *string, uint16_t x = 50, uint16_t y = 10, uint8_t width = 220, uint8_t version = 6);


### PR DESCRIPTION

- moved inlined code from .cpp to .h file for the following functions:
  - `startWrite`
  - `endWrite`
  - `writePixels`
- restored [missing](https://github.com/m5stack/M5Stack/blob/aab5cf45bd1ab4fffd9e683ad47d19ceb3e0ac47/src/utility/Display.cpp#L2679) `progressBar` function

