### PR TITLE
Fixed compilation error with the latest ESP-IDF

### DIFF
--- a/src/utility/Sprite.cpp
+++ b/src/utility/Sprite.cpp
@@ -523,7 +523,8 @@ void TFT_eSprite::pushColor(uint32_t color, uint16_t len)
   else  if (_bpp == 8)
     pixelColor = (color & 0xE000)>>8 | (color & 0x0700)>>6 | (color & 0x0018)>>3;
 
-  // else Nothing to do for 1bpp
+  else
+    pixelColor = color;
 
   while(len--) writeColor(pixelColor);
 }


### PR DESCRIPTION
Hello. I found a compilation error in Sprite.cpp with the latest ESP-IDF.

In `TFT_eSprite::pushColor(uint32_t color, uint16_t len)`, variable `pixelColor` is passed to `writeColor` uninitialized when `_bpp == 1`.  The default build setting of ESP-IDF treats this an error. 
I found that when `_bpp == 1`, the argument of `writeColor` is used as a binary value (0 or non-zero). So the fix is simple: Just copy `color` to `pixelColor`.