### PR TITLE
fix: TextFont 2 (Font16.c) backslash like slash.

### DIFF
--- a/src/Fonts/Font16.c
+++ b/src/Fonts/Font16.c
@@ -383,8 +383,8 @@ PROGMEM const unsigned char chr_f16_5B[16] =         // 1 unsigned char per row
 
 PROGMEM const unsigned char chr_f16_5C[16] =         // 1 unsigned char per row
 {
-        0x00, 0x00, 0x04, 0x04, 0x08, 0x08, 0x10, 0x10, 0x20, 0x20, 0x40,    // row 1 - 11
-        0x40, 0x80, 0x80, 0x00, 0x00                                         // row 12 - 16
+        0x00, 0x00, 0x80, 0x80, 0x40, 0x40, 0x20, 0x20, 0x10, 0x10, 0x08,    // row 1 - 11
+        0x08, 0x04, 0x04, 0x00, 0x00                                         // row 12 - 16
 };
 
 PROGMEM const unsigned char chr_f16_5D[16] =         // 1 unsigned char per row


### PR DESCRIPTION
The backslash( char 0x5c ) in setTextFont (2) looked like a slash.
![image](https://user-images.githubusercontent.com/42724151/54734725-fbc30700-4be4-11e9-9f5c-eef3eff110e4.png)
