### PR TITLE
Tweak gamma param for IPS lcd.

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -438,7 +438,9 @@ void TFT_eSPI::init(uint8_t tc)
 
   spi_end();
   if(lcd_version) {
-    writecommand(0x21);
+    writecommand(0x21);   // Inversion ON (for IPS)
+    writecommand(ILI9341_GAMMASET);
+    writedata(0x02);
   }
   setRotation(rotation);
 


### PR DESCRIPTION
Compared with the conventional TN lcd, the color of the IPS lcd is shifted in the brighter direction.
By changing the gamma table of ILI9341, the difference from the conventional TN is reduced.