### PR TITLE
Update: TFT_eSPI SDA_READ enabled. (can readPixel readRect)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ https://docs.m5stack.com/#/en/api
 
 <table>
  <tr><td>ESP32 Chip</td><td>GPIO23</td><td>GPIO19</td><td>GPIO18</td><td>GPIO14</td><td>GPIO27</td><td>GPIO33</td><td>GPIO32</td><td>GPIO4</td></tr>
- <tr><td>ILI9341</td><td>/</td><td>MISO</td><td>CLK</td><td>CS</td><td>DC</td><td>RST</td><td>BL</td><td> </td></tr>
+ <tr><td>ILI9341</td><td>MOSI/MISO</td><td>/</td><td>CLK</td><td>CS</td><td>DC</td><td>RST</td><td>BL</td><td> </td></tr>
  <tr><td>TF Card</td><td>MOSI</td><td>MISO</td><td>CLK</td><td> </td><td> </td><td> </td><td> </td><td>CS</td></tr>
 
 </table>

--- a/src/utility/In_eSPI_Setup.h
+++ b/src/utility/In_eSPI_Setup.h
@@ -37,7 +37,7 @@
 // bi-directional SDA pin and the library will try to read this via the MOSI line.
 // To use the SDA line for reading data from the TFT uncomment the following line:
 
-// #define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 display only
+#define TFT_SDA_READ      // This option is for ESP32 ONLY, tested with ST7789 display only
 
 // For ST7789 and ILI9341 ONLY, define the colour order IF the blue and red are swapped on your display
 // Try ONE option at a time to find the correct colour order for your display
@@ -263,7 +263,7 @@
 // #define SPI_FREQUENCY  80000000
 
 // Optional reduced SPI frequency for reading TFT
-// #define SPI_READ_FREQUENCY  20000000
+#define SPI_READ_FREQUENCY  16000000
 
 // The XPT2046 requires a lower SPI clock rate of 2.5MHz so we define that here:
 // #define SPI_TOUCH_FREQUENCY  2500000


### PR DESCRIPTION
ILI9341 used in M5Stack supports MOSI half duplex.
If TFT_eSPI is set correctly, the pixel can be read out.