### PR TITLE
update: M5.Speaker.setVolume works with M5.Speaker.tone .

### DIFF
--- a/src/utility/Speaker.cpp
+++ b/src/utility/Speaker.cpp
@@ -21,6 +21,7 @@ void SPEAKER::end() {
 void SPEAKER::tone(uint16_t frequency) {
   if(!_begun) begin();
   ledcWriteTone(TONE_PIN_CHANNEL, frequency);
+  ledcWrite(TONE_PIN_CHANNEL, 0x400 >> _volume);
 }
 
 void SPEAKER::tone(uint16_t frequency, uint32_t duration) {


### PR DESCRIPTION
The volume of the tone function can be adjusted by setting the duty.

Reference links:
http://nuneno.cocolog-nifty.com/blog/2020/01/post-b9cd2c.html