### PR TITLE
Update MPU9250.cpp

### DIFF
--- a/src/utility/MPU9250.cpp
+++ b/src/utility/MPU9250.cpp
@@ -233,7 +233,7 @@ void MPU9250::calibrateMPU9250(float * gyroBias, float * accelBias) {
   delay(40); // accumulate 40 samples in 40 milliseconds = 480 bytes
 
   // At end of sample accumulation, turn off FIFO sensor read
-  writeByte(MPU9250_ADDRESS, FIFO_EN, 0x00);  // Disable gyro and accelerometer sensors for FIFO
+  //writeByte(MPU9250_ADDRESS, FIFO_EN, 0x00);  // Disable gyro and accelerometer sensors for FIFO  <--- disabling FIFO sensors cause the next line to return 0 for FIFO_COUNTH, causing divide-by-zero crash
   readBytes(MPU9250_ADDRESS, FIFO_COUNTH, 2, &data[0]); // read FIFO sample count
   fifo_count = ((uint16_t)data[0] << 8) | data[1];
   packet_count = fifo_count / 12; // How many sets of full gyro and accelerometer data for averaging


### PR DESCRIPTION
Resolving issue 250, divide-by-zero error when calibrating IMU
https://github.com/m5stack/M5Stack/issues/250