### PR TITLE
'char_count' defined but not used

### DIFF
--- a/src/utility/In_eSPI.cpp
+++ b/src/utility/In_eSPI.cpp
@@ -4304,7 +4304,6 @@ int16_t TFT_eSPI::drawChar(uint16_t uniCode, int32_t x, int32_t y)
 }
 
   // Any UTF-8 decoding must be done before calling drawChar()
-static uint32_t char_count = 0;
 int16_t TFT_eSPI::drawChar(uint16_t uniCode, int32_t x, int32_t y, uint8_t font)
 {
   if (!uniCode) return 0;


### PR DESCRIPTION
M5Stack/src/utility/In_eSPI.cpp:4307:17: warning: 'char_count' defined but not used [-Wunused-variable]
 static uint32_t char_count = 0;