### PR TITLE
Prevent double declaration

### DIFF
--- a/src/utility/quaternionFilters.cpp
+++ b/src/utility/quaternionFilters.cpp
@@ -32,7 +32,7 @@ static float GyroMeasError = PI * (40.0f / 180.0f);
 // the faster the solution converges, usually at the expense of accuracy.
 // In any case, this is the free parameter in the Madgwick filtering and
 // fusion scheme.
-static float beta = sqrt(3.0f / 4.0f) * GyroMeasError;   // Compute beta
+static float gyro_beta = sqrt(3.0f / 4.0f) * GyroMeasError;   // Compute beta
 // Compute zeta, the other free parameter in the Madgwick scheme usually
 // set to a small or zero value
 // static float zeta = sqrt(3.0f / 4.0f) * GyroMeasDrift;
@@ -120,10 +120,10 @@ void MadgwickQuaternionUpdate(float ax, float ay, float az, float gx, float gy, 
   s4 *= norm;
 
   // Compute rate of change of quaternion
-  qDot1 = 0.5f * (-q2 * gx - q3 * gy - q4 * gz) - beta * s1;
-  qDot2 = 0.5f * (q1 * gx + q3 * gz - q4 * gy) - beta * s2;
-  qDot3 = 0.5f * (q1 * gy - q2 * gz + q4 * gx) - beta * s3;
-  qDot4 = 0.5f * (q1 * gz + q2 * gy - q3 * gx) - beta * s4;
+  qDot1 = 0.5f * (-q2 * gx - q3 * gy - q4 * gz) - gyro_beta * s1;
+  qDot2 = 0.5f * (q1 * gx + q3 * gz - q4 * gy) - gyro_beta * s2;
+  qDot3 = 0.5f * (q1 * gy - q2 * gz + q4 * gx) - gyro_beta * s3;
+  qDot4 = 0.5f * (q1 * gz + q2 * gy - q3 * gx) - gyro_beta * s4;
 
   // Integrate to yield quaternion
   q1 += qDot1 * deltat;


### PR DESCRIPTION
Prevent double declaration when using esp32 and platformio with C++17
``` 
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:35:14: error: 'float beta' conflicts with a previous declaration
 static float beta = sqrt(3.0f / 4.0f) * GyroMeasError;   // Compute beta
              ^~~~
In file included from /home/got/.platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2/xtensa-esp32-elf/include/c++/8.4.0/cmath:1892,
                 from /home/got/.platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2/xtensa-esp32-elf/include/c++/8.4.0/math.h:36,
                 from /home/got/.platformio/packages/framework-arduinoespressif32@src-aeb765cc6d796f82436824e2edc6e6ef/cores/esp32/esp32-hal.h:30,
                 from /home/got/.platformio/packages/framework-arduinoespressif32@src-aeb765cc6d796f82436824e2edc6e6ef/cores/esp32/Arduino.h:36,
                 from .pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.h:4,
                 from .pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:12:
/home/got/.platformio/packages/toolchain-xtensa-esp32@8.4.0+2021r2/xtensa-esp32-elf/include/c++/8.4.0/bits/specfun.h:343:5: note: previous declaration 'typename __gnu_cxx::__promote_2<_Tp, _Up>::__type std::beta(_Tpa, _Tpb)'
     beta(_Tpa __a, _Tpb __b)
     ^~~~
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp: In function 'void MadgwickQuaternionUpdate(float, float, float, float, float, float, float, float, float, float)':
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:123:56: error: invalid operands of types '<unresolved overloaded function type>' and 'float' to binary 'operator*'
   qDot1 = 0.5f * (-q2 * gx - q3 * gy - q4 * gz) - beta * s1;
                                                   ~~~~~^~~~
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:124:55: error: invalid operands of types '<unresolved overloaded function type>' and 'float' to binary 'operator*'
   qDot2 = 0.5f * (q1 * gx + q3 * gz - q4 * gy) - beta * s2;
                                                  ~~~~~^~~~
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:125:55: error: invalid operands of types '<unresolved overloaded function type>' and 'float' to binary 'operator*'
   qDot3 = 0.5f * (q1 * gy - q2 * gz + q4 * gx) - beta * s3;
                                                  ~~~~~^~~~
.pio/libdeps/m5stack-core2/M5Core2/src/utility/quaternionFilters.cpp:126:55: error: invalid operands of types '<unresolved overloaded function type>' and 'float' to binary 'operator*'
   qDot4 = 0.5f * (q1 * gz + q2 * gy - q3 * gx) - beta * s4;
                                                  ~~~~~^~~~
``` 