### PR TITLE
Fix compiler warning: ambiguitiy between uint16_t and uint8_t argument.

### DIFF
--- a/examples/Unit/RFID_RC522/MFRC522_I2C.cpp
+++ b/examples/Unit/RFID_RC522/MFRC522_I2C.cpp
@@ -76,8 +76,8 @@ byte MFRC522::PCD_ReadRegister(
     Wire.beginTransmission(_chipAddress);
     Wire.write(reg);
     Wire.endTransmission();
-
-    Wire.requestFrom(_chipAddress, 1);
+    const uint8_t sz = 1;
+    Wire.requestFrom(_chipAddress, sz);
     value = Wire.read();
     return value;
 }  // End PCD_ReadRegister()


### PR DESCRIPTION
When compiling the MFRC522.cpp in the arduino IDE, the compiler will warn about ambiguous functions,
as it cannot decide between different versions of the  Wire.requestFrom() calls.

By explicitly using an uint8_t for the size parameter, the compiler warning goes away.
