### PR TITLE
fix problem min function

### DIFF
--- a/src/utility/In_eSPI.h
+++ b/src/utility/In_eSPI.h
@@ -611,9 +611,9 @@ static inline void swap_coord(T &a, T &b) {
     b   = t;
 }
 
-#ifndef min
+#ifndef minimum
 // Return minimum of two numbers, may already be defined
-#define min(a, b) (((a) < (b)) ? (a) : (b))
+#define minimum(a, b) (((a) < (b)) ? (a) : (b))
 #endif
 
 // This structure allows sketches to retrieve the user setup parameters at


### PR DESCRIPTION
Change min to minimum because the name min conflicts with another lib (AESLib) if we want to encrypt the data captured by m5Stack.