### PR TITLE
 Fix text size setting method in RFID_RC522 example

### DIFF
--- a/examples/Unit/RFID_RC522/RFID_RC522.ino
+++ b/examples/Unit/RFID_RC522/RFID_RC522.ino
@@ -23,7 +23,7 @@ MFRC522 mfrc522(0x28);  // Create MFRC522 instance.  创建MFRC522实例
 void setup() {
     M5.begin();             // Init M5Stack.  初始化M5Stack
     M5.Power.begin();       // Init power  初始化电源模块
-    M5.lcd.setTextSize(2);  // Set the text size to 2.  设置文字大小为2
+    M5.Lcd.setTextSize(2);  // Set the text size to 2.  设置文字大小为2
     M5.Lcd.println("MFRC522 Test");
     Wire.begin();  // Wire init, adding the I2C bus.  Wire初始化, 加入i2c总线
 


### PR DESCRIPTION
 Corrected the method call for setting text size from 'M5.lcd.setTextSize' to 'M5.Lcd.setTextSize' to match the case sensitivit
 of the M5Stack library functions. This change ensures that the text size is set correctly when the RFID_RC522 example sketch i run on M5Stack devices.